### PR TITLE
use suppressions

### DIFF
--- a/specification/vmware/resource-manager/readme.md
+++ b/specification/vmware/resource-manager/readme.md
@@ -31,35 +31,6 @@ These settings apply only when `--tag=package-2022-05-01` is specified on the co
 ``` yaml $(tag) == 'package-2022-05-01'
 input-file:
 - Microsoft.AVS/stable/2022-05-01/vmware.json
-directive:
-  - suppress: PathResourceProviderNamePascalCase
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R4009
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    reason: systemData is not in this API version
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
-    where: $.definitions.MetricDimension.properties.toBeExportedForShoebox
-    reason: standard property defined by Geneva Metrics
 ```
 
 ### Tag: package-2021-12-01
@@ -69,34 +40,6 @@ These settings apply only when `--tag=package-2021-12-01` is specified on the co
 ``` yaml $(tag) == 'package-2021-12-01'
 input-file:
 - Microsoft.AVS/stable/2021-12-01/vmware.json
-directive:
-  - suppress: R3020
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R4009
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    reason: systemData is not in this API version
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-12-01/vmware.json
-    reason: standard property defined by Geneva Metrics
 ```
 
 ### Tag: package-2021-06-01
@@ -106,35 +49,6 @@ These settings apply only when `--tag=package-2021-06-01` is specified on the co
 ``` yaml $(tag) == 'package-2021-06-01'
 input-file:
 - Microsoft.AVS/stable/2021-06-01/vmware.json
-directive:
-  - suppress: R3020
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R4009
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    reason: systemData is not in this API version
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2021-06-01/vmware.json
-    where: $.definitions.MetricDimension.properties.toBeExportedForShoebox
-    reason: standard property defined by Geneva Metrics
 ```
 
 ### Tag: package-2021-01-01-preview
@@ -144,35 +58,6 @@ These settings apply only when `--tag=package-2021-01-01-preview` is specified o
 ``` yaml $(tag) == 'package-2021-01-01-preview'
 input-file:
 - Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-directive:
-  - suppress: R3020
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R4009
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    reason: systemData is not in this API version
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-    where: $.definitions.MetricDimension.properties.toBeExportedForShoebox
-    reason: standard property defined by Geneva Metrics
 ```
 
 ### Tag: package-2020-07-17-preview
@@ -182,35 +67,6 @@ These settings apply only when `--tag=package-2020-07-17-preview` is specified o
 ``` yaml $(tag) == 'package-2020-07-17-preview'
 input-file:
 - Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-directive:
-  - suppress: R3020
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R4009
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    reason: systemData is not in this API version
-  - suppress: R3018
-    from: Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-    where: $.definitions.MetricDimension.properties.toBeExportedForShoebox
-    reason: standard property defined by Geneva Metrics
 ```
 
 ### Tag: package-2020-03-20
@@ -220,32 +76,6 @@ These settings apply only when `--tag=package-2020-03-20` is specified on the co
 ``` yaml $(tag) == 'package-2020-03-20'
 input-file:
 - Microsoft.AVS/stable/2020-03-20/vmware.json
-directive:
-  - suppress: R3020
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
-  - suppress: R3010
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    reason: list by immediate parent operations are defined
-  - suppress: R3027
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    reasons: the PrivateClouds_List operation is by resource group
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    where: $.definitions.Operation.properties.isDataAction
-    reason: standard property for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    where: $.definitions.MetricSpecification.properties.fillGapWithZero
-    reason: standard property for MetricSpecification
-  - suppress: R2001
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    where: $.definitions.Operation.properties.properties
-    reason: x-ms-client-flatten not needed for Operation
-  - suppress: R3018
-    from: Microsoft.AVS/stable/2020-03-20/vmware.json
-    where: $.definitions.MetricDimension.properties.toBeExportedForShoebox
-    reason: standard property defined by Geneva Metrics
 ```
 
 ---
@@ -268,24 +98,15 @@ swagger-to-sdk:
 ```
 
 ## Suppression
-```
+``` yaml
 suppressions:
-
-  - code: SECRET_PROPERTY
-    reason: Secrets are OK to return in a POST response.
-    from:
-      - Microsoft.AVS/stable/2022-05-01/vmware.json
-      - Microsoft.AVS/stable/2021-12-01/vmware.json
-      - Microsoft.AVS/stable/2021-06-01/vmware.json
-      - Microsoft.AVS/preview/2021-01-01-preview/vmware.json
-      - Microsoft.AVS/preview/2020-07-17-preview/vmware.json
-      - Microsoft.AVS/stable/2020-03-20/vmware.json
-    where:
-      - $.definitions.AdminCredentials.properties.nsxtPassword
-      - $.definitions.AdminCredentials.properties.vcenterPassword
     
+  - code: pathresourceprovidernamepascalcase
+    reason: Microsoft.AVS was chosen over Microsoft.AzureVMwareSolution
+    from: vmware.json
+
   - code: ParametersOrder
-    reason: It is a breaking change to update the parameters order.
+    reason: Breaking change to update the parameters order
     from: vmware.json
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dhcpConfigurations/{dhcpId}"].get
@@ -295,9 +116,17 @@ suppressions:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsZones/{dnsZoneId}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/publicIPs/{publicIPId}"].delete
     
-  - code PathResourceProviderNamePascalCase
-    reason: abc
-    from: Microsoft.AVS/stable/2022-05-01/vmware.json
+  # TODO
+  - code: ConsistentPatchProperties
+  - code: DefinitionsPropertiesNamesCamelCase
+  - code: DeleteOperationAsyncResponseValidation
+  - code: IgnoredPropertyNextToRef
+  - code: LroLocationHeader
+  - code: LroPatch202
+  - code: PatchSkuProperty
+  - code: RequiredReadOnlySystemData
+  - code: UnSupportedPatchProperties
+  - code: XmsLongRunningOperationOptions
 ```
 
 ## TypeScript

--- a/specification/vmware/resource-manager/readme.md
+++ b/specification/vmware/resource-manager/readme.md
@@ -269,8 +269,10 @@ swagger-to-sdk:
 
 ## Suppression
 ```
-directive:
-  - suppress: SECRET_PROPERTY
+suppressions:
+
+  - code: SECRET_PROPERTY
+    reason: Secrets are OK to return in a POST response.
     from:
       - Microsoft.AVS/stable/2022-05-01/vmware.json
       - Microsoft.AVS/stable/2021-12-01/vmware.json
@@ -281,8 +283,9 @@ directive:
     where:
       - $.definitions.AdminCredentials.properties.nsxtPassword
       - $.definitions.AdminCredentials.properties.vcenterPassword
-    reason: Secrets are OK to return in a POST response.
-  - suppress: ParametersOrder
+    
+  - code: ParametersOrder
+    reason: It is a breaking change to update the parameters order.
     from: vmware.json
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dhcpConfigurations/{dhcpId}"].get
@@ -291,7 +294,10 @@ directive:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsServices/{dnsServiceId}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsZones/{dnsZoneId}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/publicIPs/{publicIPId}"].delete
-    reason: It is a breaking change to update the parameters order.
+    
+  - code PathResourceProviderNamePascalCase
+    reason: abc
+    from: Microsoft.AVS/stable/2022-05-01/vmware.json
 ```
 
 ## TypeScript


### PR DESCRIPTION
This moves to use the `suppressions` configuration and removes the deprecated `suppress` directives.

Trying out https://github.com/Azure/autorest/issues/4620 .

```
PS C:\Users\cataggar\io\azure-rest-api-specs> autorest --v3 --version:3.9.2 --spectral --validation --azure-validator --semantic-validator=false --model-validator=false --openapi-type=arm --use=@microsoft.azure/openapi-validator@2.0.0-beta.3 --tag=package-2022-05-01 specification\vmware\resource-manager\readme.md > out.txt
Unexpected error while logging TypeError: text.replace is not a function
    at color (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12498:10)
    at PrettyLogFormatter.log (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:11819:54)
    at ConsoleLoggerSink.log (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:11573:37)
    at ConsoleLogger.emitLog (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12124:18)
    at ConsoleLogger.log (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12120:14)
    at AutorestAsyncLogger.emitLog (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12157:18)
    at AutorestAsyncLogger.logMessageAsync (C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12171:14)
    at C:\Users\cataggar\.autorest\@autorest_core@3.9.2\node_modules\@autorest\core\dist\src_lib_autorest-core_ts.js:12215:17
```