### PR TITLE
add a pattern for privateCloudName

### DIFF
--- a/specification/vmware/Microsoft.AVS/parameters.tsp
+++ b/specification/vmware/Microsoft.AVS/parameters.tsp
@@ -7,6 +7,6 @@ namespace Microsoft.AVS;
 model PrivateCloudParameter {
   @path
   @doc("Name of the private cloud")
-  // @pattern("^[-\\w\\._]+$");
+  @pattern("^[-\\w\\._]+$");
   privateCloudName: string;
 }

--- a/specification/vmware/Microsoft.AVS/parameters.tsp
+++ b/specification/vmware/Microsoft.AVS/parameters.tsp
@@ -7,6 +7,6 @@ namespace Microsoft.AVS;
 model PrivateCloudParameter {
   @path
   @doc("Name of the private cloud")
-  @pattern("^[-\\w\\._]+$");
+  @pattern("^[-\\w\\._]+$")
   privateCloudName: string;
 }

--- a/specification/vmware/resource-manager/Microsoft.AVS/stable/2023-03-01/vmware.json
+++ b/specification/vmware/resource-manager/Microsoft.AVS/stable/2023-03-01/vmware.json
@@ -8407,6 +8407,7 @@
       "description": "Name of the private cloud",
       "required": true,
       "type": "string",
+      "pattern": "^[-\\w\\._]+$",
       "x-ms-parameter-location": "method"
     }
   }


### PR DESCRIPTION

C:/Users/cataggar/ms/azure-rest-api-specs/specification/vmware/Microsoft.AVS/parameters.tsp:10:3 - error decorator-wrong-target: Cannot apply @pattern decorator to type it is not a string
> 10 |   @pattern("^[-\\w\\._]+$");
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^

Found 263 errors.

